### PR TITLE
feat: add Helm Chart for CAPT controller

### DIFF
--- a/charts/capt/Chart.yaml
+++ b/charts/capt/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: capt
+description: A Cluster API provider that leverages Terraform to create and manage EKS clusters on AWS
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.2.1
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.2.1"
+keywords:
+  - kubernetes
+  - cluster-api
+  - eks
+  - aws
+  - terraform
+  - crossplane
+home: https://github.com/appthrust/capt
+sources:
+  - https://github.com/appthrust/capt
+maintainers:
+  - name: AppThrust
+    url: https://github.com/appthrust

--- a/charts/capt/templates/_helpers.tpl
+++ b/charts/capt/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "capt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "capt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "capt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "capt.labels" -}}
+helm.sh/chart: {{ include "capt.chart" . }}
+{{ include "capt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "capt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "capt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "capt.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "capt.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/capt/templates/captcluster-crd.yaml
+++ b/charts/capt/templates/captcluster-crd.yaml
@@ -1,0 +1,238 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captclusters.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: CAPTCluster
+    listKind: CAPTClusterList
+    plural: captclusters
+    singular: captcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.vpcId
+      name: VPC-ID
+      type: string
+    - jsonPath: .status.ready
+      name: READY
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CAPTCluster is the Schema for the captclusters API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CAPTClusterSpec defines the desired state of CAPTCluster
+            properties:
+              existingVpcId:
+                description: |-
+                  ExistingVPCID is the ID of an existing VPC to use
+                  If specified, VPCTemplateRef must not be set
+                type: string
+              region:
+                description: Region is the AWS region where the cluster will be created
+                type: string
+              retainVpcOnDelete:
+                description: |-
+                  RetainVPCOnDelete specifies whether to retain the VPC when the parent cluster is deleted
+                  This is useful when the VPC is shared among multiple projects
+                  This field is only effective when VPCTemplateRef is set
+                type: boolean
+              vpcConfig:
+                description: VPCConfig contains VPC-specific configuration
+                properties:
+                  name:
+                    description: |-
+                      Name is the name of the VPC
+                      If not specified, defaults to {cluster-name}-vpc
+                    type: string
+                type: object
+              vpcTemplateRef:
+                description: |-
+                  VPCTemplateRef is a reference to a WorkspaceTemplate resource for VPC configuration
+                  If specified, a new VPC will be created using this template
+                properties:
+                  name:
+                    description: Name of the referenced WorkspaceTemplate
+                    type: string
+                  namespace:
+                    description: Namespace of the referenced WorkspaceTemplate
+                    type: string
+                required:
+                - name
+                type: object
+              workspaceTemplateApplyName:
+                description: |-
+                  WorkspaceTemplateApplyName is the name of the WorkspaceTemplateApply used for this cluster.
+                  This field is managed by the controller and should not be modified manually.
+                type: string
+            required:
+            - region
+            type: object
+          status:
+            description: CAPTClusterStatus defines the observed state of CAPTCluster
+            properties:
+              conditions:
+                description: Conditions defines current service state of the CAPTCluster
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure
+                        provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is
+                        suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  FailureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              ready:
+                description: Ready denotes that the cluster infrastructure is ready
+                type: boolean
+              vpcId:
+                description: |-
+                  VPCID is the ID of the VPC being used
+                  This could be either a newly created VPC or an existing one
+                type: string
+              vpcWorkspaceName:
+                description: VPCWorkspaceName is the name of the associated VPC Terraform
+                  Workspace
+                type: string
+              workspaceTemplateStatus:
+                description: WorkspaceTemplateStatus contains the status of the WorkspaceTemplate
+                properties:
+                  lastAppliedRevision:
+                    description: LastAppliedRevision is the revision of the WorkspaceTemplate
+                      that was last applied
+                    type: string
+                  lastAppliedTime:
+                    description: LastAppliedTime is the last time the template was applied
+                    format: date-time
+                    type: string
+                  lastFailedRevision:
+                    description: LastFailedRevision is the revision of the WorkspaceTemplate
+                      that last failed
+                    type: string
+                  lastFailureMessage:
+                    description: LastFailureMessage contains the error message from
+                      the last failure
+                    type: string
+                  ready:
+                    description: Ready indicates if the WorkspaceTemplate is ready
+                    type: boolean
+                  workspaceName:
+                    description: WorkspaceName is the name of the associated workspace
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captcluster-editor-rbac.yaml
+++ b/charts/capt/templates/captcluster-editor-rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captcluster-editor-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters/status
+  verbs:
+  - get

--- a/charts/capt/templates/captcluster-viewer-rbac.yaml
+++ b/charts/capt/templates/captcluster-viewer-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captcluster-viewer-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters/status
+  verbs:
+  - get

--- a/charts/capt/templates/captcontrolplane-crd.yaml
+++ b/charts/capt/templates/captcontrolplane-crd.yaml
@@ -1,0 +1,318 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captcontrolplanes.controlplane.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    kind: CAPTControlPlane
+    listKind: CAPTControlPlaneList
+    plural: captcontrolplanes
+    singular: captcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Control Plane Ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Control Plane Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: API Server Endpoint
+      jsonPath: .spec.controlPlaneEndpoint.host
+      name: Endpoint
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CAPTControlPlane is the Schema for the captcontrolplanes API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CAPTControlPlaneSpec defines the desired state of CAPTControlPlane
+            properties:
+              additionalTags:
+                additionalProperties:
+                  type: string
+                description: AdditionalTags is an optional set of tags to add to AWS
+                  resources managed by the AWS provider.
+                type: object
+              controlPlaneConfig:
+                description: ControlPlaneConfig contains additional configuration for
+                  the EKS control plane.
+                properties:
+                  addons:
+                    description: Addons defines the EKS addons to be installed
+                    items:
+                      description: Addon represents an EKS addon
+                      properties:
+                        configurationValues:
+                          description: ConfigurationValues is a string containing configuration
+                            values
+                          type: string
+                        name:
+                          description: Name is the name of the addon
+                          type: string
+                        version:
+                          description: Version is the version of the addon
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  endpointAccess:
+                    description: EndpointAccess defines the access configuration for
+                      the API server endpoint
+                    properties:
+                      private:
+                        description: Private controls whether the API server has private
+                          access
+                        type: boolean
+                      public:
+                        description: Public controls whether the API server has public
+                          access
+                        type: boolean
+                      publicCIDRs:
+                        description: PublicCIDRs is a list of CIDR blocks that can access
+                          the API server
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  region:
+                    description: Region specifies the AWS region where the control plane
+                      will be created
+                    pattern: ^[a-z]{2}-[a-z]+-[0-9]$
+                    type: string
+                  timeouts:
+                    description: Timeouts defines timeout settings for various operations
+                    properties:
+                      controlPlaneTimeout:
+                        default: 30
+                        description: ControlPlaneTimeout is the timeout in minutes for
+                          control plane creation
+                        minimum: 1
+                        type: integer
+                      vpcReadyTimeout:
+                        default: 15
+                        description: VPCReadyTimeout is the timeout in minutes for VPC
+                          ready check
+                        minimum: 1
+                        type: integer
+                    type: object
+                required:
+                - region
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate
+                  with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+              workspaceTemplateApplyName:
+                description: |-
+                  WorkspaceTemplateApplyName is the name of the WorkspaceTemplateApply used for this control plane.
+                  This field is managed by the controller and should not be modified manually.
+                type: string
+              workspaceTemplateRef:
+                description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                  used for creating the control plane.
+                properties:
+                  name:
+                    description: Name is the name of the WorkspaceTemplate.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the WorkspaceTemplate.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - version
+            - workspaceTemplateRef
+            type: object
+          status:
+            description: CAPTControlPlaneStatus defines the observed state of CAPTControlPlane
+            properties:
+              conditions:
+                description: Conditions defines current service state of the CAPTControlPlane.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes if the control plane has been initialized
+                type: boolean
+              phase:
+                description: |-
+                  Phase represents the current phase of the control plane
+                  Valid values are: "Creating", "Ready", "Failed"
+                enum:
+                - Creating
+                - Ready
+                - Failed
+                type: string
+              ready:
+                description: Ready denotes that the control plane is ready
+                type: boolean
+              secretsReady:
+                default: false
+                description: SecretsReady denotes that all required secrets have been
+                  created and are ready
+                type: boolean
+              workspaceStatus:
+                description: WorkspaceStatus contains the status of the associated Workspace
+                properties:
+                  atProvider:
+                    description: AtProvider contains the observed state of the provider
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  ready:
+                    description: Ready indicates if the Workspace is ready
+                    type: boolean
+                  state:
+                    description: State represents the current state of the Workspace
+                    type: string
+                type: object
+              workspaceTemplateStatus:
+                description: WorkspaceTemplateStatus contains the status of the WorkspaceTemplate
+                properties:
+                  lastAppliedRevision:
+                    description: LastAppliedRevision is the revision of the WorkspaceTemplate
+                      that was last applied
+                    type: string
+                  lastFailedRevision:
+                    description: LastFailedRevision is the revision of the WorkspaceTemplate
+                      that last failed
+                    type: string
+                  lastFailureMessage:
+                    description: LastFailureMessage contains the error message from
+                      the last failure
+                    type: string
+                  outputs:
+                    additionalProperties:
+                      type: string
+                    description: Outputs contains the outputs from the WorkspaceTemplate
+                    type: object
+                  ready:
+                    description: Ready indicates if the WorkspaceTemplate is ready
+                    type: boolean
+                  state:
+                    description: State represents the current state of the WorkspaceTemplate
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captcontrolplanetemplate-crd.yaml
+++ b/charts/capt/templates/captcontrolplanetemplate-crd.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captcontrolplanetemplates.controlplane.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: CaptControlPlaneTemplate
+    listKind: CaptControlPlaneTemplateList
+    plural: captcontrolplanetemplates
+    singular: captcontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CaptControlPlaneTemplate is the Schema for the captcontrolplanetemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CaptControlPlaneTemplateSpec defines the desired state of CaptControlPlaneTemplate
+            properties:
+              template:
+                description: Template is the template for the CaptControlPlane
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Spec is the specification of the desired behavior of the CaptControlPlane.
+                      This spec allows for all the same configuration as CaptControlPlane.
+                    properties:
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is an optional set of tags to add
+                          to AWS resources managed by the AWS provider.
+                        type: object
+                      controlPlaneConfig:
+                        description: ControlPlaneConfig contains additional configuration
+                          for the EKS control plane.
+                        properties:
+                          addons:
+                            description: Addons defines the EKS addons to be installed
+                            items:
+                              description: Addon represents an EKS addon
+                              properties:
+                                configurationValues:
+                                  description: ConfigurationValues is a string containing
+                                    configuration values
+                                  type: string
+                                name:
+                                  description: Name is the name of the addon
+                                  type: string
+                                version:
+                                  description: Version is the version of the addon
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          endpointAccess:
+                            description: EndpointAccess defines the access configuration
+                              for the API server endpoint
+                            properties:
+                              private:
+                                description: Private controls whether the API server
+                                  has private access
+                                type: boolean
+                              public:
+                                description: Public controls whether the API server
+                                  has public access
+                                type: boolean
+                              publicCIDRs:
+                                description: PublicCIDRs is a list of CIDR blocks that
+                                  can access the API server
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          region:
+                            description: Region specifies the AWS region where the control
+                              plane will be created
+                            pattern: ^[a-z]{2}-[a-z]+-[0-9]$
+                            type: string
+                          timeouts:
+                            description: Timeouts defines timeout settings for various
+                              operations
+                            properties:
+                              controlPlaneTimeout:
+                                default: 30
+                                description: ControlPlaneTimeout is the timeout in minutes
+                                  for control plane creation
+                                minimum: 1
+                                type: integer
+                              vpcReadyTimeout:
+                                default: 15
+                                description: VPCReadyTimeout is the timeout in minutes
+                                  for VPC ready check
+                                minimum: 1
+                                type: integer
+                            type: object
+                        required:
+                        - region
+                        type: object
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint used
+                          to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                        type: string
+                      workspaceTemplateApplyName:
+                        description: |-
+                          WorkspaceTemplateApplyName is the name of the WorkspaceTemplateApply used for this control plane.
+                          This field is managed by the controller and should not be modified manually.
+                        type: string
+                      workspaceTemplateRef:
+                        description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                          used for creating the control plane.
+                        properties:
+                          name:
+                            description: Name is the name of the WorkspaceTemplate.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the WorkspaceTemplate.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - version
+                    - workspaceTemplateRef
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captmachine-crd.yaml
+++ b/charts/capt/templates/captmachine-crd.yaml
@@ -1,0 +1,198 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captmachines.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: CaptMachine
+    listKind: CaptMachineList
+    plural: captmachines
+    singular: captmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Machine Ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: EC2 Instance ID
+      jsonPath: .status.instanceId
+      name: Instance ID
+      type: string
+    - description: Node Group name
+      jsonPath: .spec.nodeGroupRef.name
+      name: Node Group
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CaptMachine is the Schema for the captmachines API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CaptMachineSpec defines the desired state of CaptMachine
+            properties:
+              instanceType:
+                description: InstanceType is the EC2 instance type to use for the node
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels is a map of kubernetes labels to apply to the node
+                type: object
+              nodeGroupRef:
+                description: NodeGroupRef is a reference to the NodeGroup this machine
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the NodeGroup
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the NodeGroup
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              tags:
+                additionalProperties:
+                  type: string
+                description: Tags is a map of tags to apply to the node
+                type: object
+              workspaceTemplateRef:
+                description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                  used for creating the machine
+                properties:
+                  name:
+                    description: Name of the referenced WorkspaceTemplate
+                    type: string
+                  namespace:
+                    description: Namespace of the referenced WorkspaceTemplate
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - instanceType
+            - nodeGroupRef
+            - workspaceTemplateRef
+            type: object
+          status:
+            description: CaptMachineStatus defines the observed state of CaptMachine
+            properties:
+              conditions:
+                description: Conditions defines current service state of the CaptMachine
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              instanceId:
+                description: InstanceID is the ID of the EC2 instance
+                type: string
+              lastTransitionTime:
+                description: LastTransitionTime is the last time the Ready condition
+                  changed
+                format: date-time
+                type: string
+              privateIp:
+                description: PrivateIP is the private IP address of the machine
+                type: string
+              ready:
+                description: Ready denotes that the machine is ready and joined to the
+                  node group
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captmachinedeployment-crd.yaml
+++ b/charts/capt/templates/captmachinedeployment-crd.yaml
@@ -1,0 +1,358 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captmachinedeployments.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: CaptMachineDeployment
+    listKind: CaptMachineDeploymentList
+    plural: captmachinedeployments
+    singular: captmachinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CaptMachineDeployment is the Schema for the captmachinedeployments
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CaptMachineDeploymentSpec defines the desired state of CaptMachineDeployment
+            properties:
+              minReadySeconds:
+                description: |-
+                  MinReadySeconds is the minimum number of seconds for which a newly created machine should
+                  be ready without any of its container crashing, for it to be considered available.
+                  Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Paused indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  ProgressDeadlineSeconds is the maximum time in seconds for a deployment to
+                  make progress before it is considered to be failed. The deployment controller will
+                  continue to process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will not be
+                  estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  Replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  RevisionHistoryLimit is the maximum number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 10.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label query over machines that should match the replica count.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: Strategy describes how to replace existing machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be scheduled above the desired number of
+                          machines.
+                          Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          Defaults to 0.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: |-
+                  Template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      instanceType:
+                        description: InstanceType is the EC2 instance type to use for
+                          the node
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of kubernetes labels to apply to
+                          the node
+                        type: object
+                      nodeGroupRef:
+                        description: NodeGroupRef is a reference to the NodeGroup this
+                          machine belongs to
+                        properties:
+                          name:
+                            description: Name is the name of the NodeGroup
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the NodeGroup
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags to apply to the node
+                        type: object
+                      workspaceTemplateRef:
+                        description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                          used for creating the machine
+                        properties:
+                          name:
+                            description: Name of the referenced WorkspaceTemplate
+                            type: string
+                          namespace:
+                            description: Namespace of the referenced WorkspaceTemplate
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - instanceType
+                    - nodeGroupRef
+                    - workspaceTemplateRef
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: CaptMachineDeploymentStatus defines the observed state of CaptMachineDeployment
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds).
+                format: int32
+                type: integer
+              collisionCount:
+                description: |-
+                  Count of hash collisions for the MachineDeployment. The MachineDeployment controller
+                  uses this field as a collision avoidance mechanism when it needs to create the name for the
+                  newest MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a deployment's
+                  current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineDeployment.
+                format: int64
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable machines targeted by this deployment. This is the total number of
+                  machines that are still required for the deployment to have 100% available capacity. They may
+                  either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: The generation observed by the deployment controller.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captmachineset-crd.yaml
+++ b/charts/capt/templates/captmachineset-crd.yaml
@@ -1,0 +1,290 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captmachinesets.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: CaptMachineSet
+    listKind: CaptMachineSetList
+    plural: captmachinesets
+    singular: captmachineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of desired machines
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Current number of machines
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: Number of ready machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Number of available machines
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CaptMachineSet is the Schema for the captmachinesets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CaptMachineSetSpec defines the desired state of CaptMachineSet
+            properties:
+              replicas:
+                description: |-
+                  Replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  Selector is a label query over machines that should match the replica count.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  Template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      instanceType:
+                        description: InstanceType is the EC2 instance type to use for
+                          the node
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of kubernetes labels to apply to
+                          the node
+                        type: object
+                      nodeGroupRef:
+                        description: NodeGroupRef is a reference to the NodeGroup this
+                          machine belongs to
+                        properties:
+                          name:
+                            description: Name is the name of the NodeGroup
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the NodeGroup
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags to apply to the node
+                        type: object
+                      workspaceTemplateRef:
+                        description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                          used for creating the machine
+                        properties:
+                          name:
+                            description: Name of the referenced WorkspaceTemplate
+                            type: string
+                          namespace:
+                            description: Namespace of the referenced WorkspaceTemplate
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - instanceType
+                    - nodeGroupRef
+                    - workspaceTemplateRef
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: CaptMachineSetStatus defines the observed state of CaptMachineSet
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds)
+                  for this machine set.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the CaptMachineSet
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for programmatic
+                  interpretation.
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels
+                  of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this machine set.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            required:
+            - replicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captmachinetemplate-crd.yaml
+++ b/charts/capt/templates/captmachinetemplate-crd.yaml
@@ -1,0 +1,166 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: captmachinetemplates.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: CaptMachineTemplate
+    listKind: CaptMachineTemplateList
+    plural: captmachinetemplates
+    singular: captmachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CaptMachineTemplate is the Schema for the captmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CaptInfraMachineTemplateSpec defines the desired state of CaptMachineTemplate
+            properties:
+              template:
+                description: Template is the template for creating a CaptMachine
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior of
+                      the machine.
+                    properties:
+                      additionalTags:
+                        additionalProperties:
+                          type: string
+                        description: AdditionalTags is a map of additional AWS tags
+                          to apply to the node group
+                        type: object
+                      instanceType:
+                        description: InstanceType is the EC2 instance type to use for
+                          the node
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels is a map of kubernetes labels to apply to
+                          the node
+                        type: object
+                      nodeType:
+                        description: NodeType specifies the type of node group (ManagedNodeGroup
+                          or Fargate)
+                        enum:
+                        - ManagedNodeGroup
+                        - Fargate
+                        type: string
+                      scaling:
+                        description: Scaling defines the scaling configuration for the
+                          node group
+                        properties:
+                          desiredSize:
+                            description: DesiredSize is the desired size of the node
+                              group
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          maxSize:
+                            description: MaxSize is the maximum size of the node group
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          minSize:
+                            description: MinSize is the minimum size of the node group
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        required:
+                        - desiredSize
+                        - maxSize
+                        - minSize
+                        type: object
+                      taints:
+                        description: Taints specifies the taints to apply to the nodes
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      workspaceTemplateRef:
+                        description: WorkspaceTemplateRef is a reference to the WorkspaceTemplate
+                          used for creating the machine
+                        properties:
+                          name:
+                            description: Name of the referenced WorkspaceTemplate
+                            type: string
+                          namespace:
+                            description: Namespace of the referenced WorkspaceTemplate
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - nodeType
+                    - workspaceTemplateRef
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/captmachinetemplate-editor-rbac.yaml
+++ b/charts/capt/templates/captmachinetemplate-editor-rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captmachinetemplate-editor-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captmachinetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captmachinetemplates/status
+  verbs:
+  - get

--- a/charts/capt/templates/captmachinetemplate-viewer-rbac.yaml
+++ b/charts/capt/templates/captmachinetemplate-viewer-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captmachinetemplate-viewer-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captmachinetemplates/status
+  verbs:
+  - get

--- a/charts/capt/templates/captvpctemplate-editor-rbac.yaml
+++ b/charts/capt/templates/captvpctemplate-editor-rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captvpctemplate-editor-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captvpctemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captvpctemplates/status
+  verbs:
+  - get

--- a/charts/capt/templates/captvpctemplate-viewer-rbac.yaml
+++ b/charts/capt/templates/captvpctemplate-viewer-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-captvpctemplate-viewer-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captvpctemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captvpctemplates/status
+  verbs:
+  - get

--- a/charts/capt/templates/controlplane-captcontrolplane-editor-rbac.yaml
+++ b/charts/capt/templates/controlplane-captcontrolplane-editor-rbac.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-controlplane-captcontrolplane-editor-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes/status
+  verbs:
+  - get

--- a/charts/capt/templates/controlplane-captcontrolplane-viewer-rbac.yaml
+++ b/charts/capt/templates/controlplane-captcontrolplane-viewer-rbac.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-controlplane-captcontrolplane-viewer-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes/status
+  verbs:
+  - get

--- a/charts/capt/templates/deployment.yaml
+++ b/charts/capt/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "capt.fullname" . }}-controller-manager
+  labels:
+    control-plane: controller-manager
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "capt.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+      {{- include "capt.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
+          | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
+          }}
+        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
+          | nindent 10 }}
+      securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
+        8 }}
+      serviceAccountName: {{ include "capt.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/charts/capt/templates/leader-election-rbac.yaml
+++ b/charts/capt/templates/leader-election-rbac.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "capt.fullname" . }}-leader-election-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "capt.fullname" . }}-leader-election-rolebinding
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "capt.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "capt.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/capt/templates/manager-rbac.yaml
+++ b/charts/capt/templates/manager-rbac.yaml
@@ -1,0 +1,136 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-manager-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes
+  - captcontrolplanetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes/finalizers
+  - captcontrolplanetemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - captcontrolplanes/status
+  - captcontrolplanetemplates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters
+  - captmachinedeployments
+  - captmachines
+  - captmachinesets
+  - captmachinetemplates
+  - workspacetemplateapplies
+  - workspacetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters/finalizers
+  - captmachinedeployments/finalizers
+  - captmachines/finalizers
+  - captmachinesets/finalizers
+  - workspacetemplateapplies/finalizers
+  - workspacetemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - captclusters/status
+  - captmachinedeployments/status
+  - captmachines/status
+  - captmachinesets/status
+  - captmachinetemplates/status
+  - workspacetemplateapplies/status
+  - workspacetemplates/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - tf.upbound.io
+  resources:
+  - workspaces
+  - workspaces/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "capt.fullname" . }}-manager-rolebinding
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "capt.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "capt.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/capt/templates/metrics-auth-rbac.yaml
+++ b/charts/capt/templates/metrics-auth-rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-metrics-auth-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "capt.fullname" . }}-metrics-auth-rolebinding
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "capt.fullname" . }}-metrics-auth-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "capt.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/capt/templates/metrics-reader-rbac.yaml
+++ b/charts/capt/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-metrics-reader
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/charts/capt/templates/metrics-service.yaml
+++ b/charts/capt/templates/metrics-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "capt.fullname" . }}-controller-manager-metrics-service
+  labels:
+    control-plane: controller-manager
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  selector:
+    control-plane: controller-manager
+    {{- include "capt.selectorLabels" . | nindent 4 }}
+  ports:
+  {{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/charts/capt/templates/serviceaccount.yaml
+++ b/charts/capt/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "capt.fullname" . }}-controller-manager
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/charts/capt/templates/tf-upbound-rbac.yaml
+++ b/charts/capt/templates/tf-upbound-rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "capt.fullname" . }}-tf-upbound-role
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - tf.upbound.io
+  resources:
+  - workspaces
+  - workspaces/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "capt.fullname" . }}-tf-upbound-rolebinding
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "capt.fullname" . }}-tf-upbound-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "capt.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/capt/templates/workspacetemplate-crd.yaml
+++ b/charts/capt/templates/workspacetemplate-crd.yaml
@@ -1,0 +1,528 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workspacetemplates.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: WorkspaceTemplate
+    listKind: WorkspaceTemplateList
+    plural: workspacetemplates
+    singular: workspacetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.workspaceName
+      name: WORKSPACE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: WorkspaceTemplate is the Schema for the workspacetemplates API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceTemplateSpec defines the desired state of WorkspaceTemplate
+            properties:
+              template:
+                description: Template defines the workspace template
+                properties:
+                  metadata:
+                    description: Metadata contains template-specific metadata
+                    properties:
+                      description:
+                        description: Description provides a human-readable description
+                          of the template
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags are key-value pairs that can be used to organize
+                          and categorize templates
+                        type: object
+                      version:
+                        description: Version specifies the version of this template
+                        type: string
+                    type: object
+                  spec:
+                    description: Spec defines the desired state of the workspace
+                    properties:
+                      deletionPolicy:
+                        default: Delete
+                        description: |-
+                          DeletionPolicy specifies what will happen to the underlying external
+                          when this managed resource is deleted - either "Delete" or "Orphan" the
+                          external resource.
+                          This field is planned to be deprecated in favor of the ManagementPolicies
+                          field in a future release. Currently, both could be set independently and
+                          non-default values would be honored if the feature flag is enabled.
+                          See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                        enum:
+                        - Orphan
+                        - Delete
+                        type: string
+                      forProvider:
+                        description: WorkspaceParameters are the configurable fields
+                          of a Workspace.
+                        properties:
+                          applyArgs:
+                            description: Arguments to be included in the terraform apply
+                              CLI command
+                            items:
+                              type: string
+                            type: array
+                          destroyArgs:
+                            description: Arguments to be included in the terraform destroy
+                              CLI command
+                            items:
+                              type: string
+                            type: array
+                          enableTerraformCLILogging:
+                            description: Boolean value to indicate  CLI logging of terraform
+                              execution is enabled or not
+                            type: boolean
+                          entrypoint:
+                            default: ""
+                            description: Entrypoint for `terraform init` within the
+                              module
+                            type: string
+                          env:
+                            description: Environment variables.
+                            items:
+                              description: An EnvVar specifies an environment variable
+                                to be set for the workspace.
+                              properties:
+                                configMapKeyRef:
+                                  description: A ConfigMap key containing the desired
+                                    env var value.
+                                  properties:
+                                    key:
+                                      description: Key within the referenced resource.
+                                      type: string
+                                    name:
+                                      description: Name of the referenced resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced resource.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                name:
+                                  type: string
+                                secretKeyRef:
+                                  description: A Secret key containing the desired env
+                                    var value.
+                                  properties:
+                                    key:
+                                      description: Key within the referenced resource.
+                                      type: string
+                                    name:
+                                      description: Name of the referenced resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced resource.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          initArgs:
+                            description: Arguments to be included in the terraform init
+                              CLI command
+                            items:
+                              type: string
+                            type: array
+                          inlineFormat:
+                            description: |-
+                              Specifies the format of the inline Terraform content
+                              if Source is 'Inline'
+                            enum:
+                            - HCL
+                            - JSON
+                            type: string
+                          module:
+                            description: |-
+                              The root module of this workspace; i.e. the module containing its main.tf
+                              file. When the workspace's source is 'Remote' (the default) this can be
+                              any address supported by terraform init -from-module, for example a git
+                              repository or an S3 bucket. When the workspace's source is 'Inline' the
+                              content of a simple main.tf or main.tf.json file may be written inline.
+                            type: string
+                          planArgs:
+                            description: Arguments to be included in the terraform plan
+                              CLI command
+                            items:
+                              type: string
+                            type: array
+                          source:
+                            description: Source of the root module of this workspace.
+                            enum:
+                            - Remote
+                            - Inline
+                            type: string
+                          varFiles:
+                            description: |-
+                              Files of configuration variables. Explicitly declared vars take
+                              precedence.
+                            items:
+                              description: A VarFile is a file containing many Terraform
+                                variables.
+                              properties:
+                                configMapKeyRef:
+                                  description: A ConfigMap key containing the vars file.
+                                  properties:
+                                    key:
+                                      description: Key within the referenced resource.
+                                      type: string
+                                    name:
+                                      description: Name of the referenced resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced resource.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                format:
+                                  default: HCL
+                                  description: Format of this vars file.
+                                  enum:
+                                  - HCL
+                                  - JSON
+                                  type: string
+                                secretKeyRef:
+                                  description: A Secret key containing the vars file.
+                                  properties:
+                                    key:
+                                      description: Key within the referenced resource.
+                                      type: string
+                                    name:
+                                      description: Name of the referenced resource.
+                                      type: string
+                                    namespace:
+                                      description: Namespace of the referenced resource.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  - namespace
+                                  type: object
+                                source:
+                                  description: Source of this vars file.
+                                  enum:
+                                  - ConfigMapKey
+                                  - SecretKey
+                                  type: string
+                              required:
+                              - source
+                              type: object
+                            type: array
+                          varmap:
+                            description: Terraform Variable Map. Should be a valid JSON
+                              representation of the input vars
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          vars:
+                            description: Configuration variables.
+                            items:
+                              description: A Var represents a Terraform configuration
+                                variable.
+                              properties:
+                                key:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - key
+                              - value
+                              type: object
+                            type: array
+                        required:
+                        - module
+                        - source
+                        type: object
+                      managementPolicies:
+                        default:
+                        - '*'
+                        description: |-
+                          THIS IS A BETA FIELD. It is on by default but can be opted out
+                          through a Crossplane feature flag.
+                          ManagementPolicies specify the array of actions Crossplane is allowed to
+                          take on the managed and external resources.
+                          This field is planned to replace the DeletionPolicy field in a future
+                          release. Currently, both could be set independently and non-default
+                          values would be honored if the feature flag is enabled. If both are
+                          custom, the DeletionPolicy field will be ignored.
+                          See the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223
+                          and this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md
+                        items:
+                          description: |-
+                            A ManagementAction represents an action that the Crossplane controllers
+                            can take on an external resource.
+                          enum:
+                          - Observe
+                          - Create
+                          - Update
+                          - Delete
+                          - LateInitialize
+                          - '*'
+                          type: string
+                        type: array
+                      providerConfigRef:
+                        default:
+                          name: default
+                        description: |-
+                          ProviderConfigReference specifies how the provider that will be used to
+                          create, observe, update, and delete this managed resource should be
+                          configured.
+                        properties:
+                          name:
+                            description: Name of the referenced object.
+                            type: string
+                          policy:
+                            description: Policies for referencing.
+                            properties:
+                              resolution:
+                                default: Required
+                                description: |-
+                                  Resolution specifies whether resolution of this reference is required.
+                                  The default is 'Required', which means the reconcile will fail if the
+                                  reference cannot be resolved. 'Optional' means this reference will be
+                                  a no-op if it cannot be resolved.
+                                enum:
+                                - Required
+                                - Optional
+                                type: string
+                              resolve:
+                                description: |-
+                                  Resolve specifies when this reference should be resolved. The default
+                                  is 'IfNotPresent', which will attempt to resolve the reference only when
+                                  the corresponding field is not present. Use 'Always' to resolve the
+                                  reference on every reconcile.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                type: string
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      publishConnectionDetailsTo:
+                        description: |-
+                          PublishConnectionDetailsTo specifies the connection secret config which
+                          contains a name, metadata and a reference to secret store config to
+                          which any connection details for this managed resource should be written.
+                          Connection details frequently include the endpoint, username,
+                          and password required to connect to the managed resource.
+                        properties:
+                          configRef:
+                            default:
+                              name: default
+                            description: |-
+                              SecretStoreConfigRef specifies which secret store config should be used
+                              for this ConnectionSecret.
+                            properties:
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              policy:
+                                description: Policies for referencing.
+                                properties:
+                                  resolution:
+                                    default: Required
+                                    description: |-
+                                      Resolution specifies whether resolution of this reference is required.
+                                      The default is 'Required', which means the reconcile will fail if the
+                                      reference cannot be resolved. 'Optional' means this reference will be
+                                      a no-op if it cannot be resolved.
+                                    enum:
+                                    - Required
+                                    - Optional
+                                    type: string
+                                  resolve:
+                                    description: |-
+                                      Resolve specifies when this reference should be resolved. The default
+                                      is 'IfNotPresent', which will attempt to resolve the reference only when
+                                      the corresponding field is not present. Use 'Always' to resolve the
+                                      reference on every reconcile.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    type: string
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          metadata:
+                            description: Metadata is the metadata for connection secret.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Annotations are the annotations to be added to connection secret.
+                                  - For Kubernetes secrets, this will be used as "metadata.annotations".
+                                  - It is up to Secret Store implementation for others store types.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Labels are the labels/tags to be added to connection secret.
+                                  - For Kubernetes secrets, this will be used as "metadata.labels".
+                                  - It is up to Secret Store implementation for others store types.
+                                type: object
+                              type:
+                                description: |-
+                                  Type is the SecretType for the connection secret.
+                                  - Only valid for Kubernetes Secret Stores.
+                                type: string
+                            type: object
+                          name:
+                            description: Name is the name of the connection secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      writeConnectionSecretToRef:
+                        description: |-
+                          WriteConnectionSecretToReference specifies the namespace and name of a
+                          Secret to which any connection details for this managed resource should
+                          be written. Connection details frequently include the endpoint, username,
+                          and password required to connect to the managed resource.
+                          This field is planned to be replaced in a future release in favor of
+                          PublishConnectionDetailsTo. Currently, both could be set independently
+                          and connection details would be published to both without affecting
+                          each other.
+                        properties:
+                          name:
+                            description: Name of the secret.
+                            type: string
+                          namespace:
+                            description: Namespace of the secret.
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                    required:
+                    - forProvider
+                    type: object
+                required:
+                - spec
+                type: object
+              writeConnectionSecretToRef:
+                description: |-
+                  WriteConnectionSecretToRef specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    type: string
+                  namespace:
+                    description: Namespace of the secret.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: WorkspaceTemplateStatus defines the observed state of WorkspaceTemplate
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False,
+                        or Unknown?
+                      type: string
+                    type:
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              workspaceName:
+                description: WorkspaceName is the name of the created Terraform Workspace
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/templates/workspacetemplateapply-crd.yaml
+++ b/charts/capt/templates/workspacetemplateapply-crd.yaml
@@ -1,0 +1,204 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workspacetemplateapplies.infrastructure.cluster.x-k8s.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  labels:
+  {{- include "capt.labels" . | nindent 4 }}
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - capt
+    - terraform
+    kind: WorkspaceTemplateApply
+    listKind: WorkspaceTemplateApplyList
+    plural: workspacetemplateapplies
+    shortNames:
+    - wtapply
+    singular: workspacetemplateapply
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.workspaceName
+      name: WORKSPACE
+      type: string
+    - jsonPath: .status.applied
+      name: APPLIED
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: WorkspaceTemplateApply is the Schema for the workspacetemplateapplies
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceTemplateApplySpec defines the desired state of WorkspaceTemplateApply
+            properties:
+              retainWorkspaceOnDelete:
+                description: |-
+                  RetainWorkspaceOnDelete specifies whether to retain the Workspace when this WorkspaceTemplateApply is deleted
+                  This is useful when the Workspace manages shared resources that should outlive this WorkspaceTemplateApply
+                type: boolean
+              templateRef:
+                description: TemplateRef references the WorkspaceTemplate to be applied
+                properties:
+                  name:
+                    description: Name of the referenced WorkspaceTemplate
+                    type: string
+                  namespace:
+                    description: Namespace of the referenced WorkspaceTemplate
+                    type: string
+                required:
+                - name
+                type: object
+              variables:
+                additionalProperties:
+                  type: string
+                description: Variables are used to override or provide additional variables
+                  to the workspace
+                type: object
+              waitForSecrets:
+                description: WaitForSecrets specifies a list of secrets that must exist
+                  before creating the workspace
+                items:
+                  description: A SecretReference is a reference to a secret in an arbitrary
+                    namespace.
+                  properties:
+                    name:
+                      description: Name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace of the secret.
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                type: array
+              waitForWorkspaces:
+                description: WaitForWorkspaces specifies a list of workspaces that must
+                  be ready before creating this workspace
+                items:
+                  description: WorkspaceReference defines a reference to a Workspace
+                  properties:
+                    name:
+                      description: Name of the referenced Workspace
+                      type: string
+                    namespace:
+                      description: Namespace of the referenced Workspace
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              writeConnectionSecretToRef:
+                description: |-
+                  WriteConnectionSecretToRef specifies the namespace and name of a
+                  Secret to which any connection details for this managed resource should
+                  be written.
+                properties:
+                  name:
+                    description: Name of the secret.
+                    type: string
+                  namespace:
+                    description: Namespace of the secret.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - templateRef
+            type: object
+          status:
+            description: WorkspaceTemplateApplyStatus defines the observed state of
+              WorkspaceTemplateApply
+            properties:
+              applied:
+                description: Applied indicates whether the template has been successfully
+                  applied
+                type: boolean
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time this condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A Message containing details about this condition's last transition from
+                        one status to another, if any.
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        ObservedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False,
+                        or Unknown?
+                      type: string
+                    type:
+                      description: |-
+                        Type of this condition. At most one of each condition type may apply to
+                        a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAppliedTime:
+                description: LastAppliedTime is the last time this template was applied
+                format: date-time
+                type: string
+              workspaceName:
+                description: WorkspaceName is the name of the created Terraform Workspace
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/capt/values.yaml
+++ b/charts/capt/values.yaml
@@ -1,0 +1,34 @@
+controllerManager:
+  manager:
+    args:
+    - --metrics-bind-address=:8443
+    - --leader-elect
+    - --health-probe-bind-address=:8081
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    image:
+      repository: ghcr.io/appthrust/capt
+      tag: v0.2.1
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  podSecurityContext:
+    runAsNonRoot: true
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+kubernetesClusterDomain: cluster.local
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  type: ClusterIP

--- a/docs/CAPTEP/0047-helm-chart-management.md
+++ b/docs/CAPTEP/0047-helm-chart-management.md
@@ -1,0 +1,116 @@
+# CAPTEP-0047: Helm Chart Management
+
+## Summary
+
+このCAPTEPでは、CAPTコントローラーのHelm Chart提供とその管理の自動化について提案します。主な変更点は、Helm Chartの新規提供、バージョン管理の自動化、および既存のリリースワークフローの活用です。
+
+## Motivation
+
+### 現状の課題
+
+1. デプロイ方法
+- CAPTコントローラーのHelm Chartが未提供
+- ユーザーが独自にマニフェストを管理する必要がある
+- バージョン管理やカスタマイズが困難
+
+2. バージョン管理
+- チャートのバージョンとアプリケーションのバージョンの同期が必要
+- バージョン更新時のミスのリスク
+
+### Goals
+
+- Helm Chartによるデプロイ方法の提供
+- バージョン管理の自動化
+- 既存のリリースワークフローの活用
+- ユーザーエクスペリエンスの向上
+
+### Non-Goals
+
+- 既存のチャート構造の大幅な変更
+- 他のチャート（karpenter）の移動や変更
+- リリースプロセス全体の見直し
+
+## Changes
+
+### 1. ディレクトリ構造
+
+```bash
+/charts/
+  ├── capt/           # コントローラーのチャート（新規追加）
+  └── karpenter/      # 既存のkarpenterチャート
+```
+
+### 2. バージョン管理の自動化
+
+Makefileに以下の機能を追加：
+
+```makefile
+.PHONY: update-version
+update-version: ## Update version number
+	@echo "Updating version number to $(VERSION)"
+	@sed -i 's/^VERSION = .*/VERSION = $(VERSION)/' VERSION
+	@yq e -i '.version = "$(VERSION)"' charts/capt/Chart.yaml
+	@yq e -i '.appVersion = "v$(VERSION)"' charts/capt/Chart.yaml
+```
+
+### 3. Helm Chart生成の改善
+
+```makefile
+.PHONY: helm
+helm: manifests kustomize helmify ## Generate helm charts
+	@echo "Generating Helm chart in charts/capt"
+	@mkdir -p charts/capt
+	$(KUSTOMIZE) build config/default | $(HELMIFY) charts/capt
+```
+
+### 4. リリースワークフローの活用
+
+既存の`release-helm.yml`ワークフローを活用：
+- karpenterチャートで実績のあるワークフローを使用
+- mainブランチへのプッシュで自動的にチャートをパブリッシュ
+- バージョンの重複チェック
+- GitHub Container Registryへの保存
+
+## Implementation
+
+1. チャートの生成
+```bash
+make helm  # charts/captに直接生成
+```
+
+2. Makefileの更新
+- `update-version`ターゲットの拡張
+- `helm`ターゲットの更新
+- `helmify`ターゲットのドキュメント改善
+
+3. バージョンの同期
+- VERSIONファイル
+- Chart.yamlのversion
+- Chart.yamlのappVersion
+
+## Migration
+
+新機能の追加であるため、既存のユーザーへの影響は最小限：
+- 既存の機能に影響なし
+- 新しいデプロイオプションとして提供
+- バージョン管理の自動化による信頼性の向上
+
+## Alternatives Considered
+
+### 1. 独立したバージョン管理
+
+- チャートとアプリケーションのバージョンを別々に管理
+- メリット：より柔軟なバージョニング
+- デメリット：同期の複雑さ、ミスのリスク
+
+### 2. チャートの独立リポジトリ化
+
+- チャートを別リポジトリで管理
+- メリット：関心の分離
+- デメリット：メンテナンスの複雑さ、同期の困難さ
+
+## References
+
+- [Helm Best Practices](https://helm.sh/docs/chart_best_practices/)
+- [Semantic Versioning](https://semver.org/)
+- [GitHub Container Registry](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry)


### PR DESCRIPTION
Provide Helm Chart for deploying CAPT controller:

## Changes

- Add new Helm Chart under \`/charts/capt\`
  - Generate chart from kustomize manifests using helmify
  - Implement version synchronization between app and chart
  - Add RBAC configurations and CRDs:
    - Infrastructure CRDs (CAPTCluster, CAPTMachine, etc.)
    - Control plane CRDs (CAPTControlPlane)
    - Workspace CRDs (WorkspaceTemplate)
  - Utilize existing release workflow for chart publishing

## Testing Done

- Generated chart using \`make helm\`
- Verified chart with \`helm lint\`
- Successfully installed chart in test cluster
- Confirmed version synchronization works